### PR TITLE
Meetcleo config update

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
-teams=(
-  find-and-view-tech
-  govuk-accounts
-  govuk-corona-services-tech
-  govuk-data-labs
-  govuk-platform-reliability
-)
+teams=()
 
 for team in ${teams[*]} ; do
   ./bin/seal.rb $team quotes

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -1,29 +1,19 @@
 #!/bin/bash
 
 teams=(
-  find-and-view-tech
-  govuk-accounts-tech
-  govuk-corona-services-tech
-  govuk-data-labs
-  govuk-forms
-  govuk-pay
-  govuk-platform-reliability
-  govuk-publishing-experience
-  govuk-publishing-platform
-  govuk-replatforming
-  govwifi
+  payments_infrastructure
+  odyssey
+  security_alerts
+  data
+  payments_security_experience
+  seal_team
 )
 
 for team in ${teams[*]}; do
   ./bin/seal.rb $team
 done
 
-morning_quote_teams=(
-  fun-workstream-govuk
-  fun-workstream-gds-community
-  fun-workstream-test-channel
-  govuk-green-team
-)
+morning_quote_teams=()
 
 for team in ${morning_quote_teams[*]}; do
   ./bin/seal.rb $team quotes

--- a/config/meetcleo.yml
+++ b/config/meetcleo.yml
@@ -1,15 +1,103 @@
-seal_team:
-  channel: "#seal-bot-test"
-  members:
-    - naeglinghaff
+_default_filters: &default_filters
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
-  use_labels: true
-  exclude_labels:
-    - "wip"
     - "WIP"
-    - "ignore"
+    - "[WIP]"
+    - "DO NOT MERGE"
+    - "[DO NOT MERGE]"
+
+  exclude_labels:
+    - "Waiting on copy"
+    - "Do Not Merge"
+
+  use_labels: true
+
+monet:
+  <<: *default_filters
+
+  repos:
+    - meetcleo
+
+  members:
+    - AgentAntelope
+    - RSijelmass
+    - wilco3d
+
+  channel: "#monet_squad"
+
+payments_infrastructure:
+  <<: *default_filters
+
+  repos:
+    - meetcleo
+
+  members:
+    - ClemCB
+    - davefrey
+    - kofibright
+    - sachimp
+    - tomwhatmore
+    - toypadlock
+    - FriedSock
+    - joelbiffin
+
+  channel: "#payments-infrastructure-internal"
+
+odyssey:
+  <<: *default_filters
+
+  repos:
+    - meetcleo
+
+  members:
+    - SaraBon
+    - iconpin
+    - tarawud
+    - naeglinghaff
+    - stevehook
+
+  channel: "#cash-advance-odyssey-dev"
+
+security_alerts:
+  <<: *default_filters
+
+  repos:
+    - meetcleo
+
+  members:
+    - "dependabot[bot]"
+
+  channel: "#first-responders"
+
+data:
+  <<: *default_filters
+
+  repos:
+    - analytics
+
+  members: []
+
+  channel: "#dbt-code-review"
+
+payments_security_experience:
+  <<: *default_filters
+
+  repos:
+    - meetcleo
+
+  members:
+    - CliffAw
+    - DhirenAtodaria
+    - repoocuts
+    - karimtimer
+
+  channel: "##payments-security-experience-dev"
+
+seal_team:
+  <<: *default_filters
+
+  repos:
+    - seal_the_revenge
+
   github_team: "seal_team"
+
+  channel: "#seal-bot-test"


### PR DESCRIPTION
# What
- Update config to use `meetcleo` teams

# Why
- Although we now have `github_team` this is singular and the current memberships don't directly match github teams currently. 

# Follow up
- Test that the yml changes worked. 
- Extend `github_team` feature to instead be `github_teams`?
